### PR TITLE
AC-65: Automate mac installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ Installs Docker Desktop using Homebrew Cask.
 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/neurabytes/nb-local-setup/develop/mac/bin/setup_docker_environment.sh)"
 ```
 
-## 2.6 Configure Git Commit Signing (GPG)
+### 2.6 Configure Git Commit Signing (GPG)
 Installs GPG and configures Git to sign commits and tags.
 
 **Run directly from GitHub:**

--- a/README.md
+++ b/README.md
@@ -74,8 +74,64 @@ Invoke-Expression (New-Object System.Net.WebClient).DownloadString('https://raw.
 
 ## 2. Getting Started [Mac]
 
-This section is pending and will be updated soon.
+### 2.1 Overview
+On macOS, setup is performed using Homebrew-based scripts that install and configure the core developer tools.
 
+Scripts include:
+
+- **Setup-DevEnvironment-mac.sh** – Installs or updates common developer tools via Homebrew
+- **Setup-PyEnvMac.sh** – Installs pyenv, Python, pipenv, and pre-commit
+- **Setup-DockerEnvironment-mac.sh** – Installs Docker Desktop for Mac
+- **Setup-GitGPG-mac.sh** – Installs GPG, generates keys, and configures Git signing
+
+---
+
+### 2.2 Prerequisites
+- macOS Ventura or later
+- Command Line Tools for Xcode (`xcode-select --install`)
+- Homebrew (auto-installed if missing)
+
+---
+
+### 2.3 Install Development Tools
+
+This script ensures Homebrew is installed, then installs/updates developer tools defined in the script.
+
+**Run directly from GitHub:**
+
+```bash
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/neurabytes/nb-local-setup/develop/mac/bin/Setup-DevEnvironment-mac.sh)"
+```
+
+## 2.4 Install Python using pyenv
+
+Installs `pyenv`, Python 3.11.x, `pipenv`, and `pre-commit`.
+
+**Run directly from GitHub:**
+
+```bash
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/neurabytes/nb-local-setup/develop/mac/bin/Setup-PyEnvMac.sh)"
+```
+
+
+## 2.5 Install Docker Desktop
+Installs Docker Desktop using Homebrew Cask.
+
+**Run directly from GitHub:**
+
+```bash
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/neurabytes/nb-local-setup/develop/mac/bin/Setup-DockerEnvironment-mac.sh)"
+```
+
+## 2.6 Configure Git Commit Signing (GPG)
+Installs GPG and configures Git to sign commits and tags.
+
+**Run directly from GitHub:**
+
+```
+bash
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/neurabytes/nb-local-setup/develop/mac/bin/Setup-GitGPG-mac.sh)"
+```
 
 ##  3. Security Note
 This script will request for Execution Policy Change for the session. Please make sure that you close the admin panel once the script is completed. Never execute scripts from untrusted sources on same session.

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ On macOS, setup is performed using Homebrew-based scripts that install and confi
 
 Scripts include:
 
-- **Setup-DevEnvironment-mac.sh** – Installs or updates common developer tools via Homebrew
+- **setup_dev_environment.sh** – Installs or updates common developer tools via Homebrew
 - **Setup-PyEnvMac.sh** – Installs pyenv, Python, pipenv, and pre-commit
 - **setup_docker_environment.sh** – Installs Docker Desktop for Mac
 - **setup_git_gpg.sh** – Installs GPG, generates keys, and configures Git signing

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ On macOS, setup is performed using Homebrew-based scripts that install and confi
 Scripts include:
 
 - **setup_dev_environment.sh** – Installs or updates common developer tools via Homebrew
-- **Setup-PyEnvMac.sh** – Installs pyenv, Python, pipenv, and pre-commit
+- **setup_pyenv.sh** – Installs pyenv, Python, pipenv, and pre-commit
 - **setup_docker_environment.sh** – Installs Docker Desktop for Mac
 - **setup_git_gpg.sh** – Installs GPG, generates keys, and configures Git signing
 

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Installs `pyenv`, Python 3.11.x, `pipenv`, and `pre-commit`.
 ```
 
 
-## 2.5 Install Docker Desktop
+### 2.5 Install Docker Desktop
 Installs Docker Desktop using Homebrew Cask.
 
 **Run directly from GitHub:**

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ Installs GPG and configures Git to sign commits and tags.
 
 ```
 bash
-/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/neurabytes/nb-local-setup/develop/mac/bin/Setup-GitGPG-mac.sh)"
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/neurabytes/nb-local-setup/develop/mac/bin/setup_git_gpg.sh)"
 ```
 
 ##  3. Security Note

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ This script ensures Homebrew is installed, then installs/updates developer tools
 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/neurabytes/nb-local-setup/develop/mac/bin/Setup-DevEnvironment-mac.sh)"
 ```
 
-## 2.4 Install Python using pyenv
+### 2.4 Install Python using pyenv
 
 Installs `pyenv`, Python 3.11.x, `pipenv`, and `pre-commit`.
 

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ This script ensures Homebrew is installed, then installs/updates developer tools
 **Run directly from GitHub:**
 
 ```bash
-/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/neurabytes/nb-local-setup/develop/mac/bin/Setup-DevEnvironment-mac.sh)"
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/neurabytes/nb-local-setup/develop/mac/bin/setup_dev_environment.sh)"
 ```
 
 ### 2.4 Install Python using pyenv

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Scripts include:
 
 - **Setup-DevEnvironment-mac.sh** – Installs or updates common developer tools via Homebrew
 - **Setup-PyEnvMac.sh** – Installs pyenv, Python, pipenv, and pre-commit
-- **Setup-DockerEnvironment-mac.sh** – Installs Docker Desktop for Mac
+- **setup_docker_environment.sh** – Installs Docker Desktop for Mac
 - **setup_git_gpg.sh** – Installs GPG, generates keys, and configures Git signing
 
 ---

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Installs `pyenv`, Python 3.11.x, `pipenv`, and `pre-commit`.
 **Run directly from GitHub:**
 
 ```bash
-/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/neurabytes/nb-local-setup/develop/mac/bin/Setup-PyEnvMac.sh)"
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/neurabytes/nb-local-setup/develop/mac/bin/setup_pyenv.sh)"
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -128,8 +128,7 @@ Installs GPG and configures Git to sign commits and tags.
 
 **Run directly from GitHub:**
 
-```
-bash
+```bash
 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/neurabytes/nb-local-setup/develop/mac/bin/setup_git_gpg.sh)"
 ```
 

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Scripts include:
 - **Setup-DevEnvironment-mac.sh** – Installs or updates common developer tools via Homebrew
 - **Setup-PyEnvMac.sh** – Installs pyenv, Python, pipenv, and pre-commit
 - **Setup-DockerEnvironment-mac.sh** – Installs Docker Desktop for Mac
-- **Setup-GitGPG-mac.sh** – Installs GPG, generates keys, and configures Git signing
+- **setup_git_gpg.sh** – Installs GPG, generates keys, and configures Git signing
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ Installs Docker Desktop using Homebrew Cask.
 **Run directly from GitHub:**
 
 ```bash
-/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/neurabytes/nb-local-setup/develop/mac/bin/Setup-DockerEnvironment-mac.sh)"
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/neurabytes/nb-local-setup/develop/mac/bin/setup_docker_environment.sh)"
 ```
 
 ## 2.6 Configure Git Commit Signing (GPG)

--- a/mac/bin/setup_pyenv.sh
+++ b/mac/bin/setup_pyenv.sh
@@ -6,11 +6,6 @@ if [ "$(id -u)" -eq 0 ]; then
   exit 1
 fi
 
-# Install pyenv via Homebrew
-if ! command -v pyenv >/dev/null 2>&1; then
-  brew install pyenv
-fi
-
 # Initialize pyenv for this session
 eval "$(pyenv init -)"
 

--- a/mac/bin/setup_pyenv.sh
+++ b/mac/bin/setup_pyenv.sh
@@ -1,90 +1,26 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -euo pipefail
 
-# Function to get user profiles
-get_user_profiles() {
-    ls /Users/
-}
-
-# Function to select a user profile
-select_user_profile() {
-    profiles=($(get_user_profiles))
-    for i in "${!profiles[@]}"; do
-        echo "[$((i + 1))] ${profiles[i]}"
-    done
-
-    read -p "Please select a user profile by number (1-${#profiles[@]}): " selection
-    echo "/Users/${profiles[$((selection - 1))]}"
-}
-
-# Function to confirm user profile
-confirm_user_profile() {
-    user_profile_confirmed="no"
-    while [ "$user_profile_confirmed" != "yes" ]; do
-        user_profile=$(select_user_profile)
-        read -p "You've selected the profile path: $user_profile. Is this correct? (yes/no) " confirm_profile
-        user_profile_confirmed=$confirm_profile
-    done
-    echo $user_profile
-}
-
-# Function to clone or update pyenv
-clone_or_update_pyenv() {
-    if [ -d "$pyenv_path" ]; then
-        read -p "$pyenv_path already exists. Do you want to overwrite it? (yes/no) " overwrite
-        if [ "$overwrite" == "yes" ]; then
-            echo "Removing existing directory..."
-            rm -rf "$pyenv_path"
-            echo "Cloning pyenv to $pyenv_path..."
-            git clone https://github.com/pyenv/pyenv.git "$pyenv_path"
-        else
-            echo "Skipped cloning pyenv since directory already exists and overwrite was not chosen."
-        fi
-    else
-        echo "Cloning pyenv to $pyenv_path..."
-        git clone https://github.com/pyenv/pyenv.git "$pyenv_path"
-    fi
-}
-
-# Function to add to user PATH
-add_to_user_path() {
-    local path_to_add=$1
-    echo "export PATH=\"$path_to_add:\$PATH\"" >> ~/.bash_profile
-}
-
-# Main script logic
-read -p "Please choose an action (install/uninstall): " action
-
-if [ "$action" == "install" ]; then
-
-    user_profile=$(confirm_user_profile)
-
-    # Defining the pyenv path based on the user's input
-    pyenv_path="$user_profile/.pyenv"
-
-    clone_or_update_pyenv
-
-    # Add the necessary paths to PATH variable
-    add_to_user_path "$user_profile/.pyenv/bin"
-    add_to_user_path "$user_profile/.pyenv/shims"
-
-    # Reload the profile
-    source ~/.bash_profile
-
-    # Install and set the Python version
-    pyenv install 3.11.6
-    pyenv global 3.11.6
-
-    # Check Python version
-    python --version
-    pip install pipenv
-    pyenv rehash
-
-    echo "Installation is done. Hurray!"
-
-elif [ "$action" == "uninstall" ]; then
-
-    # TODO: Add the code for uninstallation logic, similar to the installation logic.
-
-else
-    echo "Invalid action selected. Please choose 'install' or 'uninstall'."
+if [ "$(id -u)" -eq 0 ]; then
+  echo "Do not run this as root/sudo."
+  exit 1
 fi
+
+# Install pyenv via Homebrew
+if ! command -v pyenv >/dev/null 2>&1; then
+  brew install pyenv
+fi
+
+# Initialize pyenv for this session
+eval "$(pyenv init -)"
+
+# Install Python
+pyenv install -s 3.11.6
+pyenv global 3.11.6
+
+python3 --version
+
+pip install --upgrade pip
+pip install pipenv pre-commit
+
+echo "Setup complete."

--- a/mac/bin/tools.json
+++ b/mac/bin/tools.json
@@ -24,7 +24,9 @@
         "lm-studio": "0.3.29",
         "temurin17": "17.0.14.7",
         "openjdk": "25.0.0.1",
-        "gradle": "9.1.0"
+        "gradle": "9.1.0",
+        "git-credential-manager": "2.6.1",
+        "pyenv": "2.6.13"
       }
     },
     "student": {
@@ -69,7 +71,8 @@
         "dbeaver-community": "25.2.4",
         "postman": "11.46.6",
         "cursor": "2.0.69",
-        "git-credential-manager": "2.6.1"
+        "git-credential-manager": "2.6.1",
+        "pyenv": "2.6.13"
       }
     }
   },


### PR DESCRIPTION
This pull request significantly expands the macOS setup documentation in the `README.md` file. It replaces the placeholder for Mac instructions with detailed, step-by-step guidance on installing and configuring the development environment using Homebrew-based scripts. The update clarifies prerequisites, describes the purpose of each setup script, and provides direct commands for users to run each script from GitHub.

Expanded macOS setup documentation:

* Added an overview of the macOS setup process, listing all available Homebrew-based scripts for installing developer tools, Python, Docker, and Git GPG signing.
* Documented prerequisites for macOS setup, including minimum OS version, Xcode Command Line Tools, and Homebrew.
* Provided step-by-step instructions and ready-to-use commands for running each setup script directly from GitHub, covering developer tools, Python environment, Docker Desktop, and Git commit signing configuration.