### PR TITLE
AC-114: Add installation and uninstallation scripts for UV Python setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,14 +17,14 @@ This repository contains automation to setup the development environment for the
 
 ---
 
-### 1.3 Prerequisites
+### 1.2 Prerequisites
 - Windows Operating System
 - PowerShell with administrative rights
 
 ---
 
 
-### 1.4 Install Development tools
+### 1.3 Install Development tools
 
 This script will install Chocolatey first and it will either install, upgrade, or uninstall a specified list of developer tools based on the versions provided in the script.
 
@@ -37,7 +37,9 @@ Invoke-Expression (New-Object System.Net.WebClient).DownloadString('https://raw.
 
 ---
 
-### 1.5 Install Python and other packages using pyenv-win
+### 1.4 Install Python
+
+#### Using pyenv-win
 This script installs python environment manager `pyenv-win` on Windows. This will also install pipenv and pre-commit.
 
 **To Run the Script Directly from GitHub:**
@@ -47,9 +49,21 @@ Set-ExecutionPolicy Bypass -Scope Process
 Invoke-Expression (New-Object System.Net.WebClient).DownloadString('https://raw.githubusercontent.com/neurabytes/nb-local-setup/develop/windows/bin/Setup-PyEnvWin.ps1')
 ```
 
+#### Using uv
+This script installs `uv` (Universal Version Manager) to manage Python versions on Windows.
+
+**To Run the Script Directly from GitHub:**
+
+```powershell
+Set-ExecutionPolicy Bypass -Scope Process
+Invoke-Expression (New-Object System.Net.WebClient).DownloadString('https://raw.githubusercontent.com/neurabytes/nb-local-setup/develop/windows/bin/Setup-UV-Python.ps1')
+```
+
+
+
 ---
 
-### 1.6 Install Docker Desktop
+### 1.5 Install Docker Desktop
 This script installs Docker Desktop for Windows using Chocolatey.
 
 **To Run the Script Directly from GitHub:**
@@ -61,7 +75,7 @@ Invoke-Expression (New-Object System.Net.WebClient).DownloadString('https://raw.
 
 ---
 
-### 1.7 Install Git sign commit
+### 1.6 Install Git sign commit
 This script configures Git to sign commits and tags with GPG on Windows. It automates the process of installing GPG and setting it up with Git for commit signature verification.
 
 **To Run the Script Directly from GitHub:**
@@ -103,7 +117,9 @@ This script ensures Homebrew is installed, then installs/updates developer tools
 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/neurabytes/nb-local-setup/develop/mac/bin/setup_dev_environment.sh)"
 ```
 
-### 2.4 Install Python using pyenv
+### 2.4 Install Python
+
+#### 2.4.1 Using pyenv
 
 Installs `pyenv`, Python 3.11.x, `pipenv`, and `pre-commit`.
 
@@ -112,6 +128,16 @@ Installs `pyenv`, Python 3.11.x, `pipenv`, and `pre-commit`.
 ```bash
 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/neurabytes/nb-local-setup/develop/mac/bin/setup_pyenv.sh)"
 ```
+
+#### 2.4.2 Using uv
+
+Installs `uv` (Universal Version Manager) to manage Python versions.
+**Run directly from GitHub:**
+
+```bash
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/neurabytes/nb-local-setup/develop/mac/bin/ssetup_uv_python.sh)"
+```
+
 
 
 ### 2.5 Install Docker Desktop

--- a/mac/bin/setup_uv_python.sh
+++ b/mac/bin/setup_uv_python.sh
@@ -1,0 +1,262 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PYTHON_VERSION="3.11.14"
+CREDENTIALS_URL="https://raw.githubusercontent.com/neurabytes/nb-automation-devtools/develop/devtools/setup_credentials.py"
+BASE_PROJECT_DIR="$HOME/.nb/python"
+NB_PYTHON="$BASE_PROJECT_DIR/.venv/bin/python"
+
+if [ "$(id -u)" -eq 0 ]; then
+  echo "Do not run this as root/sudo."
+  exit 1
+fi
+
+# -------------------------
+# Functions
+# -------------------------
+ask_action() {
+  read -r -p "Do you want to install uv+python? (install/uninstall) " ACTION
+  case "$ACTION" in
+    install|uninstall) ;;
+    *) echo "Invalid input. Please enter 'install' or 'uninstall'." ; exit 1 ;;
+  esac
+}
+
+ensure_homebrew_uv_or_exit() {
+
+  local missing=0
+
+  if ! command -v brew >/dev/null 2>&1; then
+    echo "Homebrew is not installed."
+    missing=1
+  fi
+
+  if ! command -v uv >/dev/null 2>&1; then
+    echo "uv is not installed."
+    missing=1
+  fi
+
+  if [ "${missing:-0}" -eq 1 ]; then
+    echo ""
+    echo "Please first run the following command:"
+    echo '/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/neurabytes/nb-local-setup/develop/mac/bin/setup_dev_environment.sh)"'
+    echo ""
+    echo "After installation, re-run this script."
+    exit 1
+  fi
+}
+
+
+install_and_activate_python() {
+  echo "Installing Python ${PYTHON_VERSION} with uv (if not already installed)..."
+  uv python install "${PYTHON_VERSION}"
+
+  echo "Python versions detected/managed by uv:"
+  uv python list || true
+
+  echo "Ensuring base uv project exists at: $BASE_PROJECT_DIR"
+  mkdir -p "$BASE_PROJECT_DIR"
+
+  # Ensure this project uses the intended Python version (project-local)
+  echo "${PYTHON_VERSION}" > "$BASE_PROJECT_DIR/.python-version"
+
+  # Initialize project if missing
+  if [ ! -f "$BASE_PROJECT_DIR/pyproject.toml" ]; then
+    (cd "$BASE_PROJECT_DIR" && uv init)
+  fi
+
+  # Install deps into the project's .venv
+  (cd "$BASE_PROJECT_DIR" && uv add rich pre-commit)
+
+  # Sanity checks
+  if [ ! -x "$NB_PYTHON" ]; then
+    echo "ERROR: Expected venv python not found at $NB_PYTHON" >&2
+    exit 1
+  fi
+
+  if [ ! -x "$BASE_PROJECT_DIR/.venv/bin/pre-commit" ]; then
+    echo "ERROR: Expected pre-commit not found at $BASE_PROJECT_DIR/.venv/bin/pre-commit" >&2
+    exit 1
+  fi
+
+  echo "Version check:"
+  "$NB_PYTHON" --version || true
+
+  # Optional: enforce exact python version
+  if ! "$NB_PYTHON" -c "import sys; assert sys.version.startswith('${PYTHON_VERSION}'), sys.version"; then
+    echo "ERROR: nb venv python is not ${PYTHON_VERSION}" >&2
+    exit 1
+  fi
+
+  "$NB_PYTHON" -c "import rich; print('rich OK')" >/dev/null
+
+  echo "Base project ready. Use:"
+  echo "  Python:     $NB_PYTHON"
+  echo "  pre-commit: $BASE_PROJECT_DIR/.venv/bin/pre-commit"
+
+  echo "Versions:"
+  "$BASE_PROJECT_DIR/.venv/bin/pre-commit" --version || true
+}
+
+
+
+optional_setup_credentials() {
+  read -r -p "Do you also want to set up the credentials now? (yes/no) " ANSWER
+  case "$ANSWER" in
+    yes|y|Y)
+      echo "Downloading credentials setup script..."
+      TMP_FILE="$(mktemp -t nb_setup_credentials.XXXXXX.py)"
+
+      if curl -fsSL "$CREDENTIALS_URL" -o "$TMP_FILE"; then
+        echo "Running credentials setup script with $NB_PYTHON ..."
+        if ! "$NB_PYTHON" "$TMP_FILE"; then
+          echo "Error: credentials setup script failed." >&2
+        fi
+      else
+        echo "Error: failed to download credentials setup script from $CREDENTIALS_URL" >&2
+      fi
+
+      rm -f "$TMP_FILE"
+      ;;
+    *)
+      echo "Skipping credentials setup."
+      ;;
+  esac
+}
+
+uninstall_uv_setup() {
+  echo "Starting full uninstall of uv-based setup..."
+
+  # 1) Remove base uv project
+  rm -rf "$BASE_PROJECT_DIR" || true
+
+  # 2) Remove uv tools installed by this script
+  if command -v uv >/dev/null 2>&1; then
+    # Python: only uninstall if present
+    if uv python list 2>/dev/null | grep -q "${PYTHON_VERSION}"; then
+      uv python uninstall "${PYTHON_VERSION}" || true
+    else
+      echo "uv Python ${PYTHON_VERSION} not installed (skipping)."
+    fi
+  fi
+
+  # 3) Remove default python shims created by --default
+  rm -f \
+    "$HOME/.local/bin/python" \
+    "$HOME/.local/bin/python3" \
+    "$HOME/.local/bin/python3.11" \
+    "$HOME/.local/bin/python3.12" \
+    "$HOME/.local/bin/python3.13" \
+    2>/dev/null || true
+  hash -r 2>/dev/null || true
+
+  # 4) Remove global python pin if it matches
+  if [ -f "$HOME/.python-version" ] && grep -qx "${PYTHON_VERSION}" "$HOME/.python-version"; then
+    rm -f "$HOME/.python-version"
+  fi
+
+  # 5) Remove all uv-managed data
+  if [ -d "$HOME/.local/share/uv" ]; then
+    rm -rf "$HOME/.local/share/uv"
+  fi
+
+  # 6) Report PATH status (non-destructive)
+  report_uv_shell_path_changes
+
+  echo "Uninstall complete. uv-managed data removed."
+}
+
+
+is_local_bin_on_path() {
+  case ":$PATH:" in
+    *":$HOME/.local/bin:"*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+print_path_entries() {
+  echo ""
+  echo "Current PATH entries:"
+  echo "$PATH" | tr ':' '\n' | nl -ba
+
+  if is_local_bin_on_path; then
+    echo ""
+    echo "FLAG: PATH contains $HOME/.local/bin"
+  fi
+}
+
+report_uv_shell_path_changes() {
+  local targets=(
+    "$HOME/.zshenv"
+    "$HOME/.zprofile"
+    "$HOME/.zshrc"
+    "$HOME/.bash_profile"
+    "$HOME/.bashrc"
+    "$HOME/.profile"
+    "$HOME/.config/fish/config.fish"
+  )
+
+  echo ""
+  echo "Checking for shell PATH lines that may have been added by 'uv tool update-shell'..."
+
+  local found=0
+  for f in "${targets[@]}"; do
+    [ -f "$f" ] || continue
+
+    # Show lines that add ~/.local/bin to PATH (common outcome)
+    if grep -nF 'export PATH="$HOME/.local/bin:$PATH"' "$f" >/dev/null 2>&1; then
+      echo ""
+      echo "Found in: $f"
+      grep -nF 'export PATH="$HOME/.local/bin:$PATH"' "$f" || true
+      found=1
+    fi
+
+    # Fish common form (if applicable)
+    if grep -nF 'set -gx PATH $HOME/.local/bin $PATH' "$f" >/dev/null 2>&1; then
+      echo ""
+      echo "Found in: $f"
+      grep -nF 'set -gx PATH $HOME/.local/bin $PATH' "$f" || true
+      found=1
+    fi
+  done
+
+  if [ "$found" -eq 0 ]; then
+    echo "No matching PATH lines found in common shell config files."
+    echo "Note: uv may have updated a different file depending on your shell/environment."
+  fi
+
+  print_path_entries
+
+  if is_local_bin_on_path; then
+    echo ""
+    echo "If you want to remove $HOME/.local/bin from PATH, delete the line(s) shown above from your shell config file."
+  else
+    echo ""
+    echo "No manual PATH cleanup appears necessary."
+  fi
+}
+
+# -------------------------
+# Main
+# -------------------------
+ask_action
+
+if [ "$ACTION" = "uninstall" ]; then
+  uninstall_uv_setup
+  echo ""
+  echo "Uninstall complete."
+  exit 0
+fi
+
+# install
+ensure_homebrew_uv_or_exit
+install_and_activate_python
+
+echo ""
+echo "Setup complete."
+echo "Use:"
+echo "  $NB_PYTHON"
+echo "  $BASE_PROJECT_DIR/.venv/bin/pre-commit"
+echo "If you want it immediately in this window, run: exec \"$SHELL\""
+
+optional_setup_credentials

--- a/windows/bin/Setup-UV-Python.ps1
+++ b/windows/bin/Setup-UV-Python.ps1
@@ -1,0 +1,219 @@
+<#  nb_uv_setup_windows.ps1  (PowerShell)
+
+- Mirrors your mac script behavior, but with your “select a user profile” pattern.
+- Installs base uv project at: <SelectedUserProfile>\.nb\python
+- Pins Python via .python-version
+- Ensures venv + installs: rich, pre-commit
+- Optional: downloads & runs credentials script
+
+Prereq: uv is already installed and on PATH.
+#>
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+# -------------------------
+# Config
+# -------------------------
+$PYTHON_VERSION  = "3.11.14"
+$CREDENTIALS_URL = "https://raw.githubusercontent.com/neurabytes/nb-automation-devtools/develop/devtools/setup_credentials.py"
+
+# -------------------------
+# Admin guard
+# -------------------------
+function Test-IsAdmin {
+    return ([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdentity]::GetCurrent()
+    ).IsInRole([Security.Principal.WindowsBuiltInRole] "Administrator")
+}
+
+if (Test-IsAdmin) {
+    Write-Host "Please run this script as a non-Administrator!" -ForegroundColor Red
+    exit 1
+}
+
+# -------------------------
+# Profile selection (inspired by your pyenv script)
+# -------------------------
+function Get-UserProfiles {
+    Get-ChildItem "C:\Users\" -Directory | Select-Object -ExpandProperty Name
+}
+
+function Select-UserProfile {
+    $profiles = @(Get-UserProfiles)
+
+    Write-Host ""
+    Write-Host "Choose where to install the base uv project (.nb\python):"
+    Write-Host "[0] Use current user: $env:USERPROFILE"
+    for ($i = 0; $i -lt $profiles.Count; $i++) {
+        Write-Host ("[{0}] C:\Users\{1}" -f ($i + 1), $profiles[$i])
+    }
+
+    while ($true) {
+        $sel = Read-Host ("Select a profile by number (0-{0})" -f $profiles.Count)
+        if ($sel -match '^\d+$') {
+            $n = [int]$sel
+            if ($n -eq 0) { return $env:USERPROFILE }
+            if ($n -ge 1 -and $n -le $profiles.Count) { return ("C:\Users\{0}" -f $profiles[$n - 1]) }
+        }
+        Write-Host "Invalid selection." -ForegroundColor Yellow
+    }
+}
+
+function Confirm-UserProfile {
+    while ($true) {
+        $p = Select-UserProfile
+        $confirm = Read-Host "You've selected: $p . Is this correct? (yes/no)"
+        if ($confirm -in @("yes","y","Y")) { return $p }
+    }
+}
+
+# -------------------------
+# Actions
+# -------------------------
+function Ask-Action {
+    $action = Read-Host "Do you want to install uv+python? (install/uninstall)"
+    if ($action -ne "install" -and $action -ne "uninstall") {
+        throw "Invalid input. Please enter 'install' or 'uninstall'."
+    }
+    return $action
+}
+
+function Ensure-Uv-OrExit {
+    if (-not (Get-Command uv -ErrorAction SilentlyContinue)) {
+        Write-Host "uv is not installed or not on PATH." -ForegroundColor Red
+        Write-Host "Install uv, then re-run this script."
+        exit 1
+    }
+}
+
+function Optional-Setup-Credentials {
+    param([string]$PythonExe)
+
+    $answer = Read-Host "Do you also want to set up the credentials now? (yes/no)"
+    if ($answer -notin @("yes","y","Y")) {
+        Write-Host "Skipping credentials setup."
+        return
+    }
+
+    $tmp = Join-Path $env:TEMP ("nb_setup_credentials_{0}.py" -f ([Guid]::NewGuid().ToString("N")))
+    try {
+        Write-Host "Downloading credentials setup script..."
+        Invoke-RestMethod -Uri $CREDENTIALS_URL -OutFile $tmp
+
+        Write-Host "Running credentials setup script with $PythonExe ..."
+        & $PythonExe $tmp
+    }
+    catch {
+        Write-Warning "Credentials setup failed: $($_.Exception.Message)"
+    }
+    finally {
+        Remove-Item -Force -ErrorAction SilentlyContinue $tmp | Out-Null
+    }
+}
+
+function Install-AndActivate-Python {
+    param([string]$BaseProjectDir)
+
+    $nbPython     = Join-Path $BaseProjectDir ".venv\Scripts\python.exe"
+    $preCommitExe = Join-Path $BaseProjectDir ".venv\Scripts\pre-commit.exe"
+
+    Write-Host ""
+    Write-Host "Installing Python $PYTHON_VERSION with uv (if not already installed)..."
+    & uv python install $PYTHON_VERSION
+
+    Write-Host "Ensuring base uv project exists at: $BaseProjectDir"
+    New-Item -ItemType Directory -Force -Path $BaseProjectDir | Out-Null
+
+    # project-local pin
+    Set-Content -Path (Join-Path $BaseProjectDir ".python-version") -Value $PYTHON_VERSION -NoNewline
+
+    # init if missing
+    $pyproject = Join-Path $BaseProjectDir "pyproject.toml"
+    if (-not (Test-Path $pyproject)) {
+        Push-Location $BaseProjectDir
+        try { & uv init } finally { Pop-Location }
+    }
+
+    # deps into .venv
+    Push-Location $BaseProjectDir
+    try { & uv add rich pre-commit } finally { Pop-Location }
+
+    if (-not (Test-Path $nbPython))     { throw "ERROR: Expected venv python not found at $nbPython" }
+    if (-not (Test-Path $preCommitExe)) { throw "ERROR: Expected pre-commit not found at $preCommitExe" }
+
+    Write-Host "Version check:"
+    & $nbPython --version
+
+    # enforce exact version, same as your mac script
+    & $nbPython -c "import sys; assert sys.version.startswith('$PYTHON_VERSION'), sys.version"
+
+    & $nbPython -c "import rich; print('rich OK')" | Out-Null
+
+    Write-Host ""
+    Write-Host "Base project ready. Use:"
+    Write-Host "  Python:     $nbPython"
+    Write-Host "  pre-commit: $preCommitExe"
+    Write-Host ""
+    & $preCommitExe --version
+
+    return @{
+        NB_PYTHON  = $nbPython
+        PRECOMMIT  = $preCommitExe
+        BASE_DIR   = $BaseProjectDir
+    }
+}
+
+function Uninstall-Uv-Setup {
+    param([string]$BaseProjectDir)
+
+    Write-Host "Starting full uninstall of uv-based setup..."
+
+    Remove-Item -Recurse -Force -ErrorAction SilentlyContinue $BaseProjectDir | Out-Null
+
+    # Uninstall python version if uv reports it (best-effort)
+    if (Get-Command uv -ErrorAction SilentlyContinue) {
+        $list = ""
+        try { $list = (& uv python list | Out-String) } catch { $list = "" }
+        if ($list -match [Regex]::Escape($PYTHON_VERSION)) {
+            try { & uv python uninstall $PYTHON_VERSION } catch { Write-Host "(uv python uninstall failed; continuing)" }
+        } else {
+            Write-Host "uv Python $PYTHON_VERSION not detected (skipping uninstall)."
+        }
+    }
+
+    # Optional cleanup of uv cache dirs (best-effort; non-destructive if not present)
+    $uvCache    = Join-Path $env:LOCALAPPDATA "uv\cache"
+    $uvRoaming  = Join-Path $env:APPDATA "uv"
+    Remove-Item -Recurse -Force -ErrorAction SilentlyContinue $uvCache   | Out-Null
+    Remove-Item -Recurse -Force -ErrorAction SilentlyContinue $uvRoaming | Out-Null
+
+    Write-Host "Uninstall complete."
+}
+
+# -------------------------
+# Main
+# -------------------------
+$action = Ask-Action
+
+# choose user profile path (install/uninstall both need it)
+$userProfile = Confirm-UserProfile
+
+$baseProjectDir = Join-Path $userProfile ".nb\python"
+
+if ($action -eq "uninstall") {
+    Uninstall-Uv-Setup -BaseProjectDir $baseProjectDir
+    exit 0
+}
+
+Ensure-Uv-OrExit
+
+$result = Install-AndActivate-Python -BaseProjectDir $baseProjectDir
+
+Write-Host ""
+Write-Host "Setup complete."
+Write-Host "Use:"
+Write-Host "  $($result.NB_PYTHON)"
+Write-Host "  $($result.PRECOMMIT)"
+Write-Host "Restart PowerShell if PATH changes are needed for uv."
+
+Optional-Setup-Credentials -PythonExe $result.NB_PYTHON


### PR DESCRIPTION
Add cross-platform installer and uninstaller scripts for UV Python and update documentation so developers can install and uninstall UV Python consistently on macOS and Windows.

Why

1. Simplifies developer onboarding
2. Ensures reproducible local Python environments
3. Documents a single, supported way to manage Python via uv across OSes